### PR TITLE
Added error check in login callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ Kuzzle.prototype.loginOauthPopup = function(strategy, options, cb) {
     cb = options;
   }
   this.login(strategy, (err, res) => {
+    if (err) {
+      throw new Error(err.message)
+    }
     oauthWindow = window.open(res.headers.Location, 'kuzzleOauthPopup', windowOption);
     if (oauthWindow === undefined) {
       throw new Error('Cannot open window. Make sure it isn\'t blocked by your browser.');

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ Kuzzle.prototype.loginOauthPopup = function(strategy, options, cb) {
   }
   this.login(strategy, (err, res) => {
     if (err) {
-      throw new Error(err.message)
+      throw new Error(err.message);
     }
     oauthWindow = window.open(res.headers.Location, 'kuzzleOauthPopup', windowOption);
     if (oauthWindow === undefined) {

--- a/test/loginOauthPopup.test.js
+++ b/test/loginOauthPopup.test.js
@@ -2,7 +2,6 @@ var
   should = require('should'),
   sinon = require('sinon'),
   clock = sinon.useFakeTimers(),
-  path = require('path'),
   rewire = require('rewire'),
   sandbox;
 
@@ -20,7 +19,7 @@ describe('Test loginOauthPopup', function() {
   });
 
   it('should throw an error because Kuzzle sdk is not included in the project', function() {
-    (function(){
+    (function() {
       require('..');
     }).should.throw('kuzzle-sdk-login-oauth-popup needs the Kuzzle Javascript SDK in order to be working.');
   });
@@ -30,6 +29,23 @@ describe('Test loginOauthPopup', function() {
     (function() {
       require('..');
     }).should.throw('kuzzle-sdk-login-oauth-popup only work in a browser.');
+  });
+
+  it('should throw an error when kuzzle returns an error', function() {
+    var errorMessage = 'an error message';
+    Kuzzle = function() {
+      this.login = function(strategy, cb) {
+        cb(new Error(errorMessage), undefined);
+      };
+      this.query = sandbox.stub();
+    };
+    window = sandbox.stub();
+    window.open = sandbox.stub().returns(undefined);
+    rewire('..');
+    kuzzle = new Kuzzle();
+    (function() {
+      kuzzle.loginOauthPopup('strategy');
+    }).should.throw(errorMessage);
   });
 
   it('should throw an error because the popup cannot be open', function() {


### PR DESCRIPTION
Allows to receive an error message from Kuzzle when the `login` call fails (e.g. when the strategy is unknown)
